### PR TITLE
Make constants const instead of static

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,9 +17,9 @@ mod bcrypt;
 pub use errors::{BcryptError, BcryptResult};
 
 // Cost constants
-static MIN_COST: u32 = 4;
-static MAX_COST: u32 = 31;
-pub static DEFAULT_COST: u32 = 12;
+const MIN_COST: u32 = 4;
+const MAX_COST: u32 = 31;
+pub const DEFAULT_COST: u32 = 12;
 
 #[derive(Debug, PartialEq)]
 /// A bcrypt hash result before concatenating


### PR DESCRIPTION
So that they can be used in other constants:

```rust
const MY_COST: u32 = bcrypt::DEFAULT_COST
```